### PR TITLE
Refactor strike price out of the js bindings

### DIFF
--- a/packages/js-bindings/package.json
+++ b/packages/js-bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mithraic-labs/options-js-bindings",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Smart contract instructions bindings for mithraiclabs' solana options",
   "main": "dist/index.js",
   "module": "dist/index.es.js",
@@ -21,6 +21,7 @@
     "@project-serum/serum": "^0.13.23",
     "@solana/spl-token": "^0.0.13",
     "@solana/web3.js": "^0.91.2",
+    "bignumber.js": "^9.0.1",
     "bn.js": "^5.2.0",
     "buffer-layout": "^1.2.0",
     "rollup": "^2.39.0"

--- a/packages/js-bindings/yarn.lock
+++ b/packages/js-bindings/yarn.lock
@@ -431,6 +431,11 @@ base64-js@^1.3.1:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
+bignumber.js@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.1.tgz#8d7ba124c882bfd8e43260c67475518d0689e4e5"
+  integrity sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==
+
 bn.js@^4.11.9:
   version "4.11.9"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.9.tgz#26d556829458f9d1e81fc48952493d0ba3507828"


### PR DESCRIPTION
The js binding for initialize markets should take both amount and quote asset amount instead of strike price, so that if the frontend still has that data from on-chain (e.g. on the markets page) it can send the exact numbers back to the program.