### PR TITLE
Fix: Return writer token mint key with initialize function

### DIFF
--- a/packages/psyoptions-ts/package.json
+++ b/packages/psyoptions-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mithraic-labs/psyoptions",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Solana program instruction bindings for mithraiclabs' PsyOptions",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/packages/psyoptions-ts/src/initializeMarket.ts
+++ b/packages/psyoptions-ts/src/initializeMarket.ts
@@ -309,7 +309,8 @@ export const initializeMarket = async ({
   return {
     transaction,
     signers,
-    optionMarketDataAddress: optionMarketDataAccount.publicKey,
-    optionMintAddress: optionMintAccount.publicKey,
+    optionMarketDataKey: optionMarketDataAccount.publicKey,
+    optionMintKey: optionMintAccount.publicKey,
+    writerTokenMintKey: writerTokenMintAccount.publicKey
   };
 };


### PR DESCRIPTION
This is needed to fix https://github.com/mithraiclabs/psyoptions-frontend/issues/210

I actually got the above issue working for buy orders, but placing a sell order requires us to know the writer token mint key to check the wallet's writer token accounts. The initialize market function didn't return this, so the newly initialized market didn't have that key in state.

Also updated the names with "address" to "key" since the type is PublicKey, not a string. I think we agreed that we are going to standardize the names so that anything which is a PublicKey type ends in "key" and "address" refers to the base58 string, right? If that wasn't the plan I can revert this change though it's fine.
